### PR TITLE
Fall back to go tool to fetch non-GitHub packages.

### DIFF
--- a/bundle.go
+++ b/bundle.go
@@ -52,6 +52,8 @@ func installDeps(gofile string, mirrored bool) {
 }
 
 func getPackages(packages []*Package) {
+	setGoPath()
+
 	for _, pkg := range packages {
 		if pkg.branchIsPath() {
 			pkg.createSymlink()


### PR DESCRIPTION
`goem` assumes that all packages are Git repositories that follows GitHub naming conventions and access method. For example it will attempt to clone `github.com/example/package` using `git clone git@github.com:example/package.git`, which is not necessary true. The major disadvantage of such approach is that `golang.org/x/...` packages cannot be cloned this way.

The proposed solution is to fall back in case of non-GitHub package to `go get` after `GOPATH` is set to `.go` directory.