### PR TITLE
Dont rely on GitHub import path format

### DIFF
--- a/mirror_bundle.go
+++ b/mirror_bundle.go
@@ -7,6 +7,6 @@ var cmdMirrorBundle = &Command{
 
 func mirrorBundle(args []string) {
 	makeBase()
-	installDeps("", true)
-	resolveDeps(args, true)
+	installedPackages := installDeps("", true)
+	resolveDeps(installedPackages, args, true)
 }

--- a/package.go
+++ b/package.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"path"
@@ -47,8 +48,10 @@ func (self *Package) sourceExist() bool {
 func (self *Package) getSource() {
 	var err error
 	if self.IsGitHub() {
+		log.Printf("cloning %s", self.Name)
 		err = git.clone(self)
 	} else {
+		log.Printf("getting %s", self.Name)
 		var out []byte
 		if out, err = exec.Command("go", "get", "-d", self.Name).CombinedOutput(); err != nil {
 			err = errors.New(string(out))
@@ -107,7 +110,7 @@ func (self *Package) createSymlink() {
 
 type Packages []*Package
 
-func (self *Packages) Len() int {
+func (self Packages) Len() int {
 	return len(*self)
 }
 

--- a/package.go
+++ b/package.go
@@ -3,7 +3,6 @@ package main
 import (
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 	"path"
@@ -48,10 +47,8 @@ func (self *Package) sourceExist() bool {
 func (self *Package) getSource() {
 	var err error
 	if self.IsGitHub() {
-		log.Printf("cloning %s", self.Name)
 		err = git.clone(self)
 	} else {
-		log.Printf("getting %s", self.Name)
 		var out []byte
 		if out, err = exec.Command("go", "get", "-d", self.Name).CombinedOutput(); err != nil {
 			err = errors.New(string(out))
@@ -111,7 +108,7 @@ func (self *Package) createSymlink() {
 type Packages []*Package
 
 func (self Packages) Len() int {
-	return len(*self)
+	return len(self)
 }
 
 func (self Packages) Swap(i, j int) {


### PR DESCRIPTION
While looking for Gofiles for installed packages to resolve their dependencies `goem` assumes that each package name follows GitHub repository naming pattern `github.com/<username>/<project>` and tries to look for `.go/src/github.com/<username>/<project>/Gofile`. This assumption is not always true, for example some of `golang.org/x/...` packages import `google.golang.org/cloud`. As the result `goem` is trying to stat `google.golang.org/cloud/.travis.yml/Gofile` which returns an error different from `os.ErrNotExist` and causes premature exit leaving rest of the dependencies not installed.