### PR TITLE
allow to install package without a branch

### DIFF
--- a/bundle.go
+++ b/bundle.go
@@ -61,7 +61,7 @@ func getPackages(packages Packages) Packages {
 			pkg.createSymlink()
 			continue
 		}
-		if bundled[pkg.Name] == pkg.Branch {
+		if pkg.Branch != "" && bundled[pkg.Name] == pkg.Branch {
 			continue
 		}
 		if pkg.sourceExist() {

--- a/git.go
+++ b/git.go
@@ -165,6 +165,10 @@ func (self *Git) dirSwap(pkg *Package, dir string) string {
 }
 
 func (self *Git) checkBranch(branch string) string {
+	if branch == "" {
+		return branch
+	}
+
 	if branch[0] == '>' || branch[0] == '<' {
 		return branch[1:]
 	}

--- a/package.go
+++ b/package.go
@@ -30,6 +30,10 @@ func (self *Package) setMirroredGitUrl(mirror string) {
 }
 
 func (self *Package) branchIsPath() bool {
+	if self.Branch == "" {
+		return false
+	}
+
 	if self.Branch[0] == '/' || self.Branch[0] == '.' || self.Branch == "self" {
 		return true
 	}


### PR DESCRIPTION
For the moment, it is not possible to install a go package if it's not associated to a branch.
It raises an `index out of range` error.

Here is PR allowing it.
